### PR TITLE
Refactor engine scoring utils to synchronous

### DIFF
--- a/app/routers/score.py
+++ b/app/routers/score.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter
 from app.models.schemas import WalletData
-from app.services.engine import calculate_score
+from app.services.engine import calculate_score as engine_calculate_score
 
 
 router = APIRouter(prefix="/score")
 
 
 @router.post("/")
-async def score_wallet(data: WalletData) -> dict:
-    """Return a Bayesian risk score for the given wallet."""
-    return await calculate_score(data)
+def calculate_score(data: WalletData):
+    """Return a reputation score for the provided wallet data."""
+    return engine_calculate_score(data)

--- a/app/services/engine.py
+++ b/app/services/engine.py
@@ -13,7 +13,7 @@ def bayes_px(p_e_given_x: float, p_x: float, p_e: float) -> float:
     return max(0.0, min(px, 1.0))
 
 
-async def compute_probabilities(data: WalletData) -> tuple[float, float, float]:
+def compute_probabilities(data: WalletData) -> tuple[float, float, float]:
     """Derive probabilities from wallet data.
 
     A simple heuristic is used purely for demonstration.
@@ -24,9 +24,9 @@ async def compute_probabilities(data: WalletData) -> tuple[float, float, float]:
     return p_e_given_x, p_x, p_e
 
 
-async def calculate_score(data: WalletData) -> dict:
+def calculate_score(data: WalletData) -> dict:
     """Calculate a score for the wallet based on Bayesian inference."""
-    p_e_given_x, p_x, p_e = await compute_probabilities(data)
+    p_e_given_x, p_x, p_e = compute_probabilities(data)
     probability = bayes_px(p_e_given_x, p_x, p_e)
     score = int(probability * 1000)
     if score >= 800:

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -4,17 +4,14 @@ import sys
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
-import pytest  # noqa: E402
-from httpx import AsyncClient, ASGITransport  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
 
 
-@pytest.mark.asyncio
-async def test_score_endpoint():
+def test_score_endpoint():
     from main import app  # noqa: E402
 
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        response = await ac.post(
+    with TestClient(app) as client:
+        response = client.post(
             "/score/",
             json={"wallet_address": "0xabc", "tx_volume": 1200, "age_days": 365},
         )


### PR DESCRIPTION
## Summary
- make engine compute functions synchronous
- call engine in score router
- adjust score endpoint tests for sync logic

## Testing
- `flake8`
- `pytest -q`
- `coverage run -m pytest -q && coverage xml -o coverage.xml`


------
https://chatgpt.com/codex/tasks/task_e_6843796d11708332bb883979caf1d405