### PR TITLE
Add score engine tests

### DIFF
--- a/tests/test_score_engine.py
+++ b/tests/test_score_engine.py
@@ -1,0 +1,25 @@
+from app.services import score_engine
+
+
+def test_high_score():
+    flags = ["MIXER_USAGE", "MIXER_USAGE", "HIGH_BALANCE"]
+    score, tier, confidence = score_engine.calculate(flags)
+    assert score >= 80
+    assert tier == "AAA"
+    assert confidence == 0.95
+
+
+def test_medium_score():
+    flags = ["MIXER_USAGE", "HIGH_BALANCE"]
+    score, tier, confidence = score_engine.calculate(flags)
+    assert 50 <= score < 80
+    assert tier == "BB"
+    assert confidence == 0.95
+
+
+def test_low_score():
+    flags = ["KYC_VERIFIED", "UNKNOWN"]
+    score, tier, confidence = score_engine.calculate(flags)
+    assert score < 50
+    assert tier == "RISK"
+    assert confidence == 0.95


### PR DESCRIPTION
## Summary
- add unit tests for score_engine covering high, medium and low scenarios
- ensure scorelab router is included (already present)

## Testing
- `flake8 main.py tests/test_score_engine.py`
- `pytest -q`
- `coverage run -m pytest -q`
- `coverage report`


------
https://chatgpt.com/codex/tasks/task_e_6843978cc4908332af41960d60a6d7a4