### PR TITLE
Enable async scoring endpoint

### DIFF
--- a/app/routers/score.py
+++ b/app/routers/score.py
@@ -1,12 +1,12 @@
 from fastapi import APIRouter
 from app.models.schemas import WalletData
-from app.services.engine import calculate_score as engine_calculate_score
+from app.services import engine
 
 
 router = APIRouter(prefix="/score")
 
 
 @router.post("/")
-def calculate_score(data: WalletData):
+async def calculate_score(data: WalletData):
     """Return a reputation score for the provided wallet data."""
-    return engine_calculate_score(data)
+    return await engine.calculate_score(data)

--- a/app/services/engine.py
+++ b/app/services/engine.py
@@ -24,7 +24,7 @@ def compute_probabilities(data: WalletData) -> tuple[float, float, float]:
     return p_e_given_x, p_x, p_e
 
 
-def calculate_score(data: WalletData) -> dict:
+async def calculate_score(data: WalletData) -> dict:
     """Calculate a score for the wallet based on Bayesian inference."""
     p_e_given_x, p_x, p_e = compute_probabilities(data)
     probability = bayes_px(p_e_given_x, p_x, p_e)
@@ -40,4 +40,9 @@ def calculate_score(data: WalletData) -> dict:
         flags.append("low_probability")
     if data.tx_volume < 100:
         flags.append("low_activity")
-    return {"score": score, "tier": tier, "probability": probability, "flags": flags}
+    return {
+        "score": score,
+        "tier": tier,
+        "probability": probability,
+        "flags": flags,
+    }

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -5,18 +5,19 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
 from fastapi.testclient import TestClient  # noqa: E402
+from app.models.schemas import WalletData  # noqa: E402
+from app.services import engine  # noqa: E402
+import asyncio  # noqa: E402
 
 
 def test_score_endpoint():
     from main import app  # noqa: E402
 
+    data = {"wallet_address": "0xabc", "tx_volume": 1200, "age_days": 365}
+    expected = asyncio.run(engine.calculate_score(WalletData(**data)))
+
     with TestClient(app) as client:
-        response = client.post(
-            "/score/",
-            json={"wallet_address": "0xabc", "tx_volume": 1200, "age_days": 365},
-        )
+        response = client.post("/score/", json=data)
+
     assert response.status_code == 200
-    payload = response.json()
-    assert "score" in payload
-    assert "tier" in payload
-    assert 0 <= payload["score"] <= 1000
+    assert response.json() == expected


### PR DESCRIPTION
## Summary
- make `engine.calculate_score` asynchronous
- call async scoring from router
- update score test to check dynamic calculation

## Testing
- `flake8`
- `pytest -q`
- `coverage run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684397889c048332b4f4883a1ad3b31e