### PR TITLE
Implement extra core modules

### DIFF
--- a/app/models/compliance.py
+++ b/app/models/compliance.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from typing import List
+
+
+class ComplianceRequest(BaseModel):
+    """Input for compliance checks."""
+
+    wallet_address: str
+
+
+class ComplianceResult(BaseModel):
+    """Output of compliance verification."""
+
+    wallet: str
+    passes: bool
+    issues: List[str]

--- a/app/models/dfc.py
+++ b/app/models/dfc.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class FlagProposal(BaseModel):
+    """Data required to propose a new reputation flag."""
+
+    flag: str
+    description: str
+    user_id: str
+
+
+class FlagProposalOut(FlagProposal):
+    """Response model for a submitted proposal."""
+
+    proposal_id: str
+    status: str
+    score_shift: Optional[float] = None

--- a/app/models/gas.py
+++ b/app/models/gas.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+from typing import List
+
+
+class GasData(BaseModel):
+    """Gas usage data for analysis."""
+
+    gas_values: List[int]
+
+
+class GasAnalysis(BaseModel):
+    """Result of gas pattern analysis."""
+
+    anomalies: List[str]

--- a/app/models/mirror.py
+++ b/app/models/mirror.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+from typing import List
+
+
+class Snapshot(BaseModel):
+    """Snapshot of a wallet reputation state."""
+
+    wallet: str
+    score: int
+    flags: List[str]
+
+
+class SnapshotDiff(BaseModel):
+    """Difference between two snapshots."""
+
+    wallet: str
+    delta_score: int
+    added_flags: List[str]
+    removed_flags: List[str]

--- a/app/models/sentinela.py
+++ b/app/models/sentinela.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+
+class Event(BaseModel):
+    """Generic event monitored by Sentinela."""
+
+    wallet: str
+    gas_used: int
+    context: str
+
+
+class EventResponse(BaseModel):
+    """Outcome of event processing."""
+
+    reanalyze: bool

--- a/app/models/sigil.py
+++ b/app/models/sigil.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+from typing import List
+
+
+class SigilRequest(BaseModel):
+    """Input for minting a reputation NFT."""
+
+    wallet: str
+    score: int
+    flags: List[str]
+
+
+class SigilResult(BaseModel):
+    """Details about the minted NFT."""
+
+    token_id: str
+    ipfs_url: str

--- a/app/routers/compliance.py
+++ b/app/routers/compliance.py
@@ -1,0 +1,15 @@
+"""Endpoints for Compliance Orchestrator."""
+
+from fastapi import APIRouter
+from app.models.compliance import ComplianceRequest, ComplianceResult
+from app.services import compliance
+
+router = APIRouter(prefix="/internal/v1")
+
+
+@router.post("/compliance/check", response_model=ComplianceResult)
+async def check(req: ComplianceRequest) -> ComplianceResult:
+    """Run compliance verification for a wallet."""
+
+    result = await compliance.check_compliance(req.wallet_address)
+    return ComplianceResult(**result)

--- a/app/routers/dfc.py
+++ b/app/routers/dfc.py
@@ -1,0 +1,19 @@
+"""Routers for Dynamic Flag Council operations."""
+
+from fastapi import APIRouter
+from app.models.dfc import FlagProposal, FlagProposalOut
+from app.services import dfc
+
+router = APIRouter(prefix="/internal/v1")
+
+
+@router.post("/dfc/proposals", response_model=FlagProposalOut)
+async def propose_flag(proposal: FlagProposal) -> FlagProposalOut:
+    """Submit a flag change proposal and simulate its impact."""
+
+    record = dfc.register_proposal(proposal.dict(), proposal.user_id)
+    impact = dfc.simulate_flag_impact(record)
+    record.update(impact)
+    if impact["score_shift"] > 5:
+        record["status"] = "APPROVED_FOR_STAGING"
+    return FlagProposalOut(**record)

--- a/app/routers/gas_monitor.py
+++ b/app/routers/gas_monitor.py
@@ -1,0 +1,15 @@
+"""Endpoints for Gas Monitor."""
+
+from fastapi import APIRouter
+from app.models.gas import GasData, GasAnalysis
+from app.services import gas_monitor
+
+router = APIRouter(prefix="/internal/v1")
+
+
+@router.post("/gasmonitor/analyze", response_model=GasAnalysis)
+async def analyze_gas(data: GasData) -> GasAnalysis:
+    """Analyze gas usage and return detected anomalies."""
+
+    result = await gas_monitor.analyze_gas(data.gas_values)
+    return GasAnalysis(**result)

--- a/app/routers/mirror_engine.py
+++ b/app/routers/mirror_engine.py
@@ -1,0 +1,15 @@
+"""Endpoints for Mirror Engine."""
+
+from fastapi import APIRouter
+from app.models.mirror import Snapshot, SnapshotDiff
+from app.services import mirror_engine
+
+router = APIRouter(prefix="/internal/v1")
+
+
+@router.post("/mirror/snapshot", response_model=SnapshotDiff)
+async def snapshot(data: Snapshot) -> SnapshotDiff:
+    """Store a snapshot and get difference from previous one."""
+
+    diff = mirror_engine.snapshot_event(data.dict())
+    return SnapshotDiff(**diff)

--- a/app/routers/sentinela.py
+++ b/app/routers/sentinela.py
@@ -1,0 +1,15 @@
+"""Endpoints for Sentinela monitoring service."""
+
+from fastapi import APIRouter
+from app.models.sentinela import Event, EventResponse
+from app.services import sentinela
+
+router = APIRouter(prefix="/internal/v1")
+
+
+@router.post("/sentinela/event", response_model=EventResponse)
+async def process(event: Event) -> EventResponse:
+    """Process an incoming event and signal if reanalysis is needed."""
+
+    result = await sentinela.process_event(event.dict())
+    return EventResponse(**result)

--- a/app/routers/sigilmesh.py
+++ b/app/routers/sigilmesh.py
@@ -1,0 +1,15 @@
+"""Endpoints for SigilMesh NFT minting."""
+
+from fastapi import APIRouter
+from app.models.sigil import SigilRequest, SigilResult
+from app.services import sigilmesh
+
+router = APIRouter(prefix="/internal/v1")
+
+
+@router.post("/sigilmesh/mint", response_model=SigilResult)
+async def mint_sigil(data: SigilRequest) -> SigilResult:
+    """Mint a reputation NFT from analysis results."""
+
+    result = await sigilmesh.mint_reputation_nft(data.dict())
+    return SigilResult(**result)

--- a/app/services/compliance.py
+++ b/app/services/compliance.py
@@ -1,0 +1,18 @@
+"""Compliance Orchestrator logic."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from app.services import kyc
+
+
+async def check_compliance(wallet_address: str) -> Dict:
+    """Perform basic compliance checks using KYC information."""
+
+    identity = await kyc.get_identity(wallet_address)
+    issues = []
+    if not identity.get("verified"):
+        issues.append("KYC_MISSING")
+    passes = not issues
+    return {"wallet": wallet_address, "passes": passes, "issues": issues}

--- a/app/services/dfc.py
+++ b/app/services/dfc.py
@@ -1,0 +1,46 @@
+"""Dynamic Flag Council service logic."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Dict, List
+
+_proposals: Dict[str, Dict] = {}
+
+
+def register_proposal(flag_data: Dict, user_id: str) -> Dict:
+    """Register a flag change proposal.
+
+    Args:
+        flag_data: Information about the new flag.
+        user_id: Identifier of the proposing user.
+
+    Returns:
+        Proposal record with generated ID and status.
+    """
+
+    proposal_id = str(uuid.uuid4())
+    proposal = {
+        "proposal_id": proposal_id,
+        "flag": flag_data.get("flag"),
+        "description": flag_data.get("description", ""),
+        "user_id": user_id,
+        "status": "PENDING",
+    }
+    _proposals[proposal_id] = proposal
+    return proposal
+
+
+def simulate_flag_impact(proposal: Dict) -> Dict[str, float]:
+    """Simulate impact of a proposal on scoring logic."""
+
+    # Simplistic impact: flags with certain keywords have higher score impact
+    flag = proposal.get("flag", "")
+    score_shift = 10.0 if "mixer" in flag.lower() else 2.0
+    return {"score_shift": score_shift}
+
+
+def list_proposals() -> List[Dict]:
+    """Return all stored proposals."""
+
+    return list(_proposals.values())

--- a/app/services/gas_monitor.py
+++ b/app/services/gas_monitor.py
@@ -1,0 +1,19 @@
+"""Analyze gas usage patterns."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+async def analyze_gas(gas_values: List[int]) -> Dict:
+    """Return anomalies based on gas usage statistics."""
+
+    if not gas_values:
+        return {"anomalies": []}
+    avg = sum(gas_values) / len(gas_values)
+    anomalies: List[str] = []
+    if avg > 150:
+        anomalies.append("HIGH_AVG_GAS")
+    if max(gas_values) - min(gas_values) > 200:
+        anomalies.append("VOLATILE_GAS")
+    return {"anomalies": anomalies}

--- a/app/services/mirror_engine.py
+++ b/app/services/mirror_engine.py
@@ -1,0 +1,34 @@
+"""Mirror Engine compares snapshot evolution."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+_snapshots: Dict[str, Dict] = {}
+
+
+def snapshot_event(data: Dict) -> Dict:
+    """Store a snapshot and return difference from previous state."""
+
+    wallet = data["wallet"]
+    previous = _snapshots.get(wallet)
+    _snapshots[wallet] = {"score": data["score"], "flags": list(data["flags"])}
+    if not previous:
+        return {"wallet": wallet, "delta_score": 0, "added_flags": [], "removed_flags": []}
+    delta_score = data["score"] - previous["score"]
+    added_flags = [f for f in data["flags"] if f not in previous["flags"]]
+    removed_flags = [f for f in previous["flags"] if f not in data["flags"]]
+    return {
+        "wallet": wallet,
+        "delta_score": delta_score,
+        "added_flags": added_flags,
+        "removed_flags": removed_flags,
+    }
+
+
+def get_history(wallet: str) -> List[Dict]:
+    """Retrieve stored history for a wallet."""
+
+    if wallet in _snapshots:
+        return [{"wallet": wallet, **_snapshots[wallet]}]
+    return []

--- a/app/services/sentinela.py
+++ b/app/services/sentinela.py
@@ -1,0 +1,13 @@
+"""Sentinela monitoring service."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+async def process_event(event: Dict) -> Dict:
+    """Analyze an event and decide if a wallet should be reanalyzed."""
+
+    gas_used = event.get("gas_used", 0)
+    reanalyze = gas_used > 200
+    return {"reanalyze": reanalyze}

--- a/app/services/sigilmesh.py
+++ b/app/services/sigilmesh.py
@@ -1,0 +1,14 @@
+"""Mint reputation NFTs."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Dict
+
+
+async def mint_reputation_nft(data: Dict) -> Dict:
+    """Simulate minting a reputation NFT and return metadata."""
+
+    token_id = str(uuid.uuid4())
+    ipfs_url = f"ipfs://{token_id}"
+    return {"token_id": token_id, "ipfs_url": ipfs_url}

--- a/main.py
+++ b/main.py
@@ -1,5 +1,14 @@
 from fastapi import FastAPI
-from app.routers import score, scorelab
+from app.routers import (
+    score,
+    scorelab,
+    dfc,
+    mirror_engine,
+    gas_monitor,
+    sigilmesh,
+    sentinela,
+    compliance,
+)
 
 
 app = FastAPI()
@@ -7,6 +16,12 @@ app = FastAPI()
 app.include_router(score.router)
 
 app.include_router(scorelab.router)
+app.include_router(dfc.router)
+app.include_router(mirror_engine.router)
+app.include_router(gas_monitor.router)
+app.include_router(sigilmesh.router)
+app.include_router(sentinela.router)
+app.include_router(compliance.router)
 
 
 @app.get("/")

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import httpx
+from httpx import AsyncClient
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from main import app  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_compliance_check():
+    transport = httpx.ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post(
+            "/internal/v1/compliance/check",
+            json={"wallet_address": "0x1"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["passes"] is True
+    assert data["issues"] == []

--- a/tests/test_dfc.py
+++ b/tests/test_dfc.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import httpx
+from httpx import AsyncClient
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from main import app  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_proposal_flow():
+    transport = httpx.ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post(
+            "/internal/v1/dfc/proposals",
+            json={"flag": "MIXER_USAGE", "description": "mixers", "user_id": "u1"},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["proposal_id"]
+    assert data["status"] in {"PENDING", "APPROVED_FOR_STAGING"}

--- a/tests/test_gas_monitor.py
+++ b/tests/test_gas_monitor.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+import httpx
+from httpx import AsyncClient
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from main import app  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_gas_analysis():
+    transport = httpx.ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post(
+            "/internal/v1/gasmonitor/analyze",
+            json={"gas_values": [100, 250, 300]},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert "HIGH_AVG_GAS" in data["anomalies"]

--- a/tests/test_mirror_engine.py
+++ b/tests/test_mirror_engine.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+import httpx
+from httpx import AsyncClient
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from main import app  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_snapshot_diff():
+    transport = httpx.ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.post(
+            "/internal/v1/mirror/snapshot",
+            json={"wallet": "0x1", "score": 50, "flags": ["A"]},
+        )
+        response = await ac.post(
+            "/internal/v1/mirror/snapshot",
+            json={"wallet": "0x1", "score": 60, "flags": ["A", "B"]},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["delta_score"] == 10
+    assert "B" in data["added_flags"]

--- a/tests/test_sentinela.py
+++ b/tests/test_sentinela.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+import httpx
+from httpx import AsyncClient
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from main import app  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_event_reanalysis():
+    transport = httpx.ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post(
+            "/internal/v1/sentinela/event",
+            json={"wallet": "0x1", "gas_used": 300, "context": "tx"},
+        )
+    assert response.status_code == 200
+    assert response.json()["reanalyze"] is True

--- a/tests/test_sigilmesh.py
+++ b/tests/test_sigilmesh.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import httpx
+from httpx import AsyncClient
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from main import app  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_mint_sigil():
+    transport = httpx.ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        response = await ac.post(
+            "/internal/v1/sigilmesh/mint",
+            json={"wallet": "0x1", "score": 80, "flags": ["A"]},
+        )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["token_id"]
+    assert data["ipfs_url"].startswith("ipfs://")


### PR DESCRIPTION
## Summary
- add new service logic for DFC, Mirror Engine, Gas Monitor, SigilMesh, Sentinela and Compliance
- expose new endpoints for each service
- define pydantic schemas for new modules
- hook routers into API
- cover new behaviour with pytest

## Testing
- `python -m flake8`
- `pytest -q`
- `coverage run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843bb35204c83329075650ff2aa477c