### PR TITLE
Implement score result persistence

### DIFF
--- a/app/services/scorelab_service.py
+++ b/app/services/scorelab_service.py
@@ -24,6 +24,17 @@ async def analyze(wallet_address: str) -> dict:
     flags = aggregate_flags(onchain_flags, identity)
     score, tier, confidence = score_engine.calculate(flags)
 
+    result = {
+        "wallet": wallet_address,
+        "flags": flags,
+        "score": score,
+        "tier": tier,
+        "confidence": confidence,
+    }
+
+    db = get_db()
+    await db.analysis.insert_one(result)
+    return result
 
 async def get_analysis(wallet_address: str) -> dict | None:
     """Retrieve the latest analysis for a wallet."""


### PR DESCRIPTION
## Summary
- store the analyzed wallet result inside MongoDB

## Testing
- `flake8 app/services/scorelab_service.py`
- `pytest tests/test_scorelab_core.py -k analyze -q` *(fails: ModuleNotFoundError: No module named 'src')*
- `coverage run -m pytest` *(fails: 5 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6844010953b0833281cb5626ba6152ee