### PR TITLE
Fix async call for calculate_score

### DIFF
--- a/src/routers/score.py
+++ b/src/routers/score.py
@@ -8,4 +8,4 @@ router = APIRouter(prefix="/score")
 @router.post("/")
 async def calculate_score(data: WalletData):
     """Return a reputation score using ``src`` utilities."""
-    return engine_calculate_score(data)
+    return await engine_calculate_score(data)

--- a/src/services/engine.py
+++ b/src/services/engine.py
@@ -21,8 +21,10 @@ def compute_probabilities(data: WalletData) -> tuple[float, float, float]:
     return p_e_given_x, p_x, p_e
 
 
-def calculate_score(data: WalletData) -> dict:
+async def calculate_score(data: WalletData) -> dict:
     """Calculate a score for the wallet based on Bayesian inference."""
+    # Computation itself is synchronous but exposed via ``async`` for
+    # compatibility with async service layers.
     p_e_given_x, p_x, p_e = compute_probabilities(data)
     probability = bayes_px(p_e_given_x, p_x, p_e)
     score = int(probability * 1000)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -6,6 +6,7 @@ sys.path.insert(0, ROOT)
 
 from src.services.engine import bayes_px, calculate_score  # noqa: E402
 from src.models import WalletData  # noqa: E402
+import asyncio
 
 
 def test_bayes_px_bounds():
@@ -15,5 +16,5 @@ def test_bayes_px_bounds():
 
 def test_calculate_score():
     data = WalletData(wallet_address="0xabc", tx_volume=1200, age_days=365)
-    result = calculate_score(data)
+    result = asyncio.run(calculate_score(data))
     assert "score" in result and "tier" in result and "probability" in result


### PR DESCRIPTION
## Summary
- change `src.services.engine.calculate_score` to be async
- await engine call in score router
- adjust `tests/test_engine.py` for async function

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError, IndentationError)*
- `coverage run -m pytest -q` *(fails: ModuleNotFoundError, IndentationError)*
- `coverage report`

------
https://chatgpt.com/codex/tasks/task_e_6844010b444c833282fb0a9fbbf1c64f