### PR TITLE
Fix missing imports in db utils

### DIFF
--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -1,5 +1,9 @@
 
+
 """Wrapper around ``src.utils`` database helpers."""
+
+import os
+from functools import lru_cache
 
 MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
 


### PR DESCRIPTION
## Summary
- update `app/utils/db.py` imports to prevent NameError

## Testing
- `flake8 app/utils/db.py`
- `flake8 | head -n 5` *(fails: various errors)*
- `pytest -q` *(fails: missing modules, syntax errors)*
- `coverage run -m pytest -q` *(fails: import errors)*
- `coverage report`

------
https://chatgpt.com/codex/tasks/task_e_68440106609c8332bd5817cd595d82ba