### PR TITLE
Fix flag list handling in scorelab_core

### DIFF
--- a/src/scorelab_core/core.py
+++ b/src/scorelab_core/core.py
@@ -11,8 +11,8 @@ def aggregate_flags(onchain_flags: List[str], identity: dict) -> List[str]:
     """Combine on-chain flags with identity information."""
     flags = sorted(set(onchain_flags))
     if identity.get("verified"):
-        unique.append("KYC_VERIFIED")
-    return unique
+        flags.append("KYC_VERIFIED")
+    return flags
 
 
 async def analyze(wallet_address: str) -> dict:

--- a/src/utils/db.py
+++ b/src/utils/db.py
@@ -1,0 +1,6 @@
+"""Database utilities."""
+
+
+def get_db():
+    """Return a database handle (placeholder)."""
+    raise NotImplementedError


### PR DESCRIPTION
## Summary
- fix aggregate_flags to update `flags` list
- add placeholder get_db for imports

## Testing
- `flake8 src/scorelab_core/core.py src/utils/db.py`
- `PYTHONPATH=. pytest -q tests/test_scorelab_core.py`
- `PYTHONPATH=. coverage run -m pytest tests/test_scorelab_core.py && coverage report`


------
https://chatgpt.com/codex/tasks/task_e_6844010843008332b69e786e5cc95025