### PR TITLE
Add SigilMesh NFT mint route

### DIFF
--- a/app/routers/sigilmesh.py
+++ b/app/routers/sigilmesh.py
@@ -1,15 +1,21 @@
+"""SigilMesh NFT minting endpoints."""
+
 from fastapi import APIRouter, HTTPException
+
 from app.models.scorelab import MintRequest, MintResult
-from app.services import sigilmesh, scorelab_service
-
-
-class MintRequest(BaseModel):
-    analysis: dict
+from app.services import sigilmesh
 
 
 router = APIRouter(prefix="/internal/v1/sigilmesh")
 
-    analysis = await scorelab_service.get_analysis(request.wallet_address)
+
+@router.post("/mint", response_model=MintResult, tags=["SigilMesh"])
+async def mint_nft(request: MintRequest) -> MintResult:
+    """Mint a reputation NFT for the given wallet."""
+
+    analysis = await sigilmesh.get_latest_analysis(request.wallet_address)
     if not analysis:
         raise HTTPException(status_code=404, detail="Analysis not found")
+
     return await sigilmesh.mint_reputation_nft(analysis)
+

--- a/app/services/sigilmesh.py
+++ b/app/services/sigilmesh.py
@@ -2,6 +2,8 @@ from datetime import datetime
 from typing import Any, Dict
 from uuid import uuid4
 
+from . import scorelab_service
+
 
 async def mint_reputation_nft(analysis: Dict[str, Any]) -> Dict[str, Any]:
     """Mint a reputation NFT representing the analysis result."""
@@ -11,6 +13,12 @@ async def mint_reputation_nft(analysis: Dict[str, Any]) -> Dict[str, Any]:
         "token_id": token_id,
         "ipfs_uri": f"ipfs://{token_id}",
         "issued_at": datetime.utcnow(),
-        "analysis": analysis,
+        "metadata": analysis,
     }
     return nft
+
+
+async def get_latest_analysis(wallet_address: str) -> Dict[str, Any] | None:
+    """Proxy to ``scorelab_service.get_analysis`` for router usage."""
+
+    return await scorelab_service.get_analysis(wallet_address)


### PR DESCRIPTION
## Summary
- add FastAPI route to mint reputation NFTs
- return NFT metadata using new get_latest_analysis helper

## Testing
- `flake8` *(fails: F821 undefined name 'analysis_data', etc.)*
- `pytest tests/test_sigilmesh.py::test_mint_endpoint -q` *(fails: ModuleNotFoundError: No module named 'cryptography')*
- `coverage run -m pytest tests/test_sigilmesh.py::test_mint_endpoint` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_e_684401092f148332b899a2afd3b4078d