### PR TITLE
Add db util re-exports

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements.txt flake8
       - name: Run checks
         run: |
           make check

--- a/src/utils/db.py
+++ b/src/utils/db.py
@@ -1,0 +1,18 @@
+"""Compatibility layer for database helpers."""
+
+from app.utils.db import get_client as app_get_client, get_db as app_get_db
+
+
+def get_client():
+    """Return the Motor client from :mod:`app.utils.db`."""
+
+    return app_get_client()
+
+
+def get_db():
+    """Return the main database handle from :mod:`app.utils.db`."""
+
+    return app_get_db()
+
+
+__all__ = ["get_client", "get_db"]

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -10,6 +10,8 @@ from app.routers.scorelab import router as scorelab_router  # noqa: E402
 from app.routers.mirror_engine import router as mirror_router  # noqa: E402
 from app.routers.sigilmesh import router as sigil_router  # noqa: E402
 from app.routers.compliance import router as compliance_router  # noqa: E402
+from app.services.compliance import compliance  # noqa: E402
+from app.routers.sigilmesh import sigilmesh  # noqa: E402
 
 app.include_router(scorelab_router)
 app.include_router(mirror_router)

--- a/tests/test_mirror_engine.py
+++ b/tests/test_mirror_engine.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)

--- a/tests/test_sentinela.py
+++ b/tests/test_sentinela.py
@@ -17,6 +17,7 @@ app.include_router(sentinela_router)
 @pytest.mark.asyncio
 async def test_monitor_reanalyzes_on_event(monkeypatch):
     analyzed = []
+    called = {"wallet": None}
 
     async def mock_analyze(wallet_address: str):
         analyzed.append(wallet_address)


### PR DESCRIPTION
## Summary
- expose `get_db` and `get_client` through `src.utils.db`
- install flake8 in CI workflow
- fix undefined names in a few tests for linting

## Testing
- `flake8` *(fails: F811 redefinition of unused 'WalletData' from line 3)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app.models.schemas')*
- `coverage run -m pytest && coverage report` *(fails: ModuleNotFoundError: No module named 'app.models.schemas')*


------
https://chatgpt.com/codex/tasks/task_e_68440107c5548332adb406b0886ec2b5