### PR TITLE
Fix aggregate_flags variable name

### DIFF
--- a/src/scorelab_core/core.py
+++ b/src/scorelab_core/core.py
@@ -11,8 +11,8 @@ def aggregate_flags(onchain_flags: List[str], identity: dict) -> List[str]:
     """Combine on-chain flags with identity information."""
     flags = sorted(set(onchain_flags))
     if identity.get("verified"):
-        unique.append("KYC_VERIFIED")
-    return unique
+        flags.append("KYC_VERIFIED")
+    return flags
 
 
 async def analyze(wallet_address: str) -> dict:


### PR DESCRIPTION
## Summary
- correct variable reference in `aggregate_flags`

## Testing
- `flake8`
- `pytest -q` *(fails: PytestUnknownMarkWarning, NameError, etc.)*
- `coverage run -m pytest && coverage report` *(fails: PytestUnknownMarkWarning, NameError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6844043681ec8332bdd53e42fc508597