### PR TITLE
Add db util re-exports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 motor
 httpx
 pydantic
+flake8

--- a/src/utils/db.py
+++ b/src/utils/db.py
@@ -1,0 +1,18 @@
+"""Compatibility layer for database helpers."""
+
+from app.utils.db import get_client as app_get_client, get_db as app_get_db
+
+
+def get_client():
+    """Return the Motor client from :mod:`app.utils.db`."""
+
+    return app_get_client()
+
+
+def get_db():
+    """Return the main database handle from :mod:`app.utils.db`."""
+
+    return app_get_db()
+
+
+__all__ = ["get_client", "get_db"]

--- a/tests/test_mirror_engine.py
+++ b/tests/test_mirror_engine.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)

--- a/tests/test_sentinela.py
+++ b/tests/test_sentinela.py
@@ -16,6 +16,7 @@ app.include_router(sentinela_router)
 
 @pytest.mark.asyncio
 async def test_monitor_reanalyzes_on_event(monkeypatch):
+    called = {}
     analyzed = []
 
     async def mock_analyze(wallet_address: str):


### PR DESCRIPTION
## Summary
- expose `get_db` and `get_client` through `src.utils.db`
- fix variable references in end-to-end test
- add flake8 requirement

## Testing
- `flake8 | head -n 20` *(fails: F401, F821, etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx', etc.)*
- `coverage run -m pytest && coverage report` *(fails: No module named 'pytest')*

------
https://chatgpt.com/codex/tasks/task_e_68440107c5548332adb406b0886ec2b5