### PR TITLE
Add db util re-exports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 motor
 httpx
 pydantic
+flake8

--- a/src/utils/db.py
+++ b/src/utils/db.py
@@ -1,0 +1,18 @@
+"""Compatibility layer for database helpers."""
+
+from app.utils.db import get_client as app_get_client, get_db as app_get_db
+
+
+def get_client():
+    """Return the Motor client from :mod:`app.utils.db`."""
+
+    return app_get_client()
+
+
+def get_db():
+    """Return the main database handle from :mod:`app.utils.db`."""
+
+    return app_get_db()
+
+
+__all__ = ["get_client", "get_db"]

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 import httpx
 from httpx import AsyncClient
+import types
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from main import app  # noqa: E402
@@ -10,6 +11,8 @@ from app.routers.scorelab import router as scorelab_router  # noqa: E402
 from app.routers.mirror_engine import router as mirror_router  # noqa: E402
 from app.routers.sigilmesh import router as sigil_router  # noqa: E402
 from app.routers.compliance import router as compliance_router  # noqa: E402
+from app.services.compliance import compliance  # noqa: E402
+from app.services import sigilmesh  # noqa: E402
 
 app.include_router(scorelab_router)
 app.include_router(mirror_router)
@@ -63,8 +66,8 @@ async def test_analysis_to_nft(monkeypatch):
             "/internal/v1/scorelab/analyze",
             json={"wallet_address": "0x" + "a" * 40},
         )
-    assert resp.status_code == 200
-    analysis = resp.json()
+    assert analysis_resp.status_code == 200
+    analysis = analysis_resp.json()
     assert analysis["wallet"] == "0x" + "a" * 40
 
     # Step 2: Mirror Engine comparison
@@ -77,13 +80,13 @@ async def test_analysis_to_nft(monkeypatch):
     def mock_check(result):
         return result["score"] >= 50
 
-        snapshot_resp = await ac.post(
-            "/internal/v1/mirror/snapshot",
-            json=analysis_data,
-        )
-        assert snapshot_resp.status_code == 200
-        snapshot_data = snapshot_resp.json()
-        assert snapshot_data["snapshot_id"] == "snap1"
+    snapshot_resp = await ac.post(
+        "/internal/v1/mirror/snapshot",
+        json=analysis,
+    )
+    assert snapshot_resp.status_code == 200
+    snapshot_data = snapshot_resp.json()
+    assert snapshot_data["snapshot_id"] == "snap1"
 
     # Execute mocked pipeline
     compared = mirror_engine.compare(analysis)

--- a/tests/test_mirror_engine.py
+++ b/tests/test_mirror_engine.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)

--- a/tests/test_sentinela.py
+++ b/tests/test_sentinela.py
@@ -16,6 +16,7 @@ app.include_router(sentinela_router)
 
 @pytest.mark.asyncio
 async def test_monitor_reanalyzes_on_event(monkeypatch):
+    called = {}
     analyzed = []
 
     async def mock_analyze(wallet_address: str):


### PR DESCRIPTION
## Summary
- expose `get_db` and `get_client` through `src.utils.db`
- fix missing imports in several tests
- add flake8 requirement
- correct variable names in `tests/test_end_to_end.py`

## Testing
- `flake8 | head -n 20` *(fails: F401, F821, etc.)*
- `pytest -q` *(fails: 10 errors during collection)*
- `coverage run -m pytest && coverage report` *(command not found / fails)*

------
https://chatgpt.com/codex/tasks/task_e_68440107c5548332adb406b0886ec2b5