### PR TITLE
Fix variable use in aggregate_flags

### DIFF
--- a/src/scorelab_core/core.py
+++ b/src/scorelab_core/core.py
@@ -8,11 +8,11 @@ analyze_wallet = sherlock.analyze_wallet
 
 
 def aggregate_flags(onchain_flags: List[str], identity: dict) -> List[str]:
-    """Combine on-chain flags with identity information."""
+    """Return a unique, sorted list of flags, adding a KYC flag when verified."""
     flags = sorted(set(onchain_flags))
     if identity.get("verified"):
-        unique.append("KYC_VERIFIED")
-    return unique
+        flags.append("KYC_VERIFIED")
+    return flags
 
 
 async def analyze(wallet_address: str) -> dict:


### PR DESCRIPTION
## Summary
- fix undefined variable in `aggregate_flags`
- clarify docstring for `aggregate_flags`

## Testing
- `flake8 src/scorelab_core/core.py`
- `pytest -q` *(fails: ModuleNotFoundError, etc.)*
- `coverage run -m pytest && coverage report` *(fails: ModuleNotFoundError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6844043681ec8332bdd53e42fc508597