### PR TITLE
Implement kyc service email encryption

### DIFF
--- a/app/services/kyc.py
+++ b/app/services/kyc.py
@@ -51,7 +51,21 @@ async def get_identity(
     except ValueError:  # pragma: no cover - invalid hex should rarely happen
         val = 0
 
-        
     even_digits = set("02468aceACE")
-    is_verified = wallet_address[-1] in even_digits
-    return {"wallet": wallet_address, "verified": is_verified}
+    is_verified = last in even_digits
+
+    if is_verified:
+        kyc_level = val % 3 + 1
+    else:
+        kyc_level = 0
+
+    email = f"user{wallet_address[2:]}@example.com"
+    if fernet:
+        email = fernet.encrypt(email.encode()).decode()
+
+    return {
+        "wallet": wallet_address,
+        "verified": is_verified,
+        "kyc_level": kyc_level,
+        "pii": {"email": email},
+    }

--- a/tests/test_kyc.py
+++ b/tests/test_kyc.py
@@ -12,13 +12,16 @@ from app.services import kyc  # noqa: E402
 @pytest.mark.asyncio
 async def test_get_identity_verified_level():
     result = await kyc.get_identity("0x1234")
+    assert result["wallet"] == "0x1234"
     assert result["verified"] is True
     assert 1 <= result["kyc_level"] <= 3
+    assert result["pii"]["email"] == "user1234@example.com"
 
 
 @pytest.mark.asyncio
 async def test_get_identity_unverified_level_zero():
     result = await kyc.get_identity("0x1235")
+    assert result["wallet"] == "0x1235"
     assert result["verified"] is False
     assert result["kyc_level"] == 0
 


### PR DESCRIPTION
## Summary
- implement verification logic in `kyc.get_identity`
- ensure generated email is returned and optionally encrypted
- expand tests for new return structure

## Testing
- `flake8 app/services/kyc.py tests/test_kyc.py`
- `pytest -q tests/test_kyc.py` *(tests skipped: missing async plugin)*
- `coverage run -m pytest tests/test_kyc.py && coverage report`

------
https://chatgpt.com/codex/tasks/task_e_68440d4f4b7083329397e04c845576aa