### PR TITLE
Fix variable name mismatch in tests

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -63,8 +63,8 @@ async def test_analysis_to_nft(monkeypatch):
             "/internal/v1/scorelab/analyze",
             json={"wallet_address": "0x" + "a" * 40},
         )
-    assert resp.status_code == 200
-    analysis = resp.json()
+    assert analysis_resp.status_code == 200
+    analysis = analysis_resp.json()
     assert analysis["wallet"] == "0x" + "a" * 40
 
     # Step 2: Mirror Engine comparison


### PR DESCRIPTION
## Summary
- rename `resp` to `analysis_resp` for clarity in end-to-end test

## Testing
- `flake8 tests/test_end_to_end.py`
- `pytest -q` *(fails: NameError in tests)*
- `coverage run -m pytest -q` *(fails: NameError in tests)*
- `coverage report`

------
https://chatgpt.com/codex/tasks/task_e_68440d5017a08332902abcfcf170f42b