### PR TITLE
Fix aggregate_flags ordering

### DIFF
--- a/app/services/scorelab_service.py
+++ b/app/services/scorelab_service.py
@@ -6,7 +6,7 @@ from app.utils.db import get_db
 def aggregate_flags(
     onchain_flags: List[str], identity: dict, gas_flags: List[str] | None = None
 ) -> List[str]:
-    """Combine flags from multiple sources."""
+    """Combine flags from all sources and return them sorted."""
 
     flags = set(onchain_flags)
     if gas_flags:

--- a/app/services/scorelab_service.py
+++ b/app/services/scorelab_service.py
@@ -1,5 +1,5 @@
 from typing import List
-from app.services import sherlock, kyc, score_engine, mirror_engine, gas_monitor
+from app.services import sherlock, kyc, score_engine
 from app.utils.db import get_db
 
 
@@ -11,10 +11,9 @@ def aggregate_flags(
     flags = set(onchain_flags)
     if gas_flags:
         flags.update(gas_flags)
-    ordered = sorted(flags)
     if identity.get("verified"):
-        ordered.append("KYC_VERIFIED")
-    return ordered
+        flags.add("KYC_VERIFIED")
+    return sorted(flags)
 
 
 async def analyze(wallet_address: str) -> dict:
@@ -35,6 +34,7 @@ async def analyze(wallet_address: str) -> dict:
     db = get_db()
     await db.analysis.insert_one(result)
     return result
+
 
 async def get_analysis(wallet_address: str) -> dict | None:
     """Retrieve the latest analysis for a wallet."""

--- a/src/scorelab_core/core.py
+++ b/src/scorelab_core/core.py
@@ -8,7 +8,7 @@ analyze_wallet = sherlock.analyze_wallet
 
 
 def aggregate_flags(onchain_flags: List[str], identity: dict) -> List[str]:
-    """Combine on-chain flags with identity information."""
+    """Return a unique, sorted list of flags, adding a KYC flag when verified."""
     flags = set(onchain_flags)
     if identity.get("verified"):
         flags.add("KYC_VERIFIED")

--- a/src/scorelab_core/core.py
+++ b/src/scorelab_core/core.py
@@ -9,10 +9,10 @@ analyze_wallet = sherlock.analyze_wallet
 
 def aggregate_flags(onchain_flags: List[str], identity: dict) -> List[str]:
     """Combine on-chain flags with identity information."""
-    flags = sorted(set(onchain_flags))
+    flags = set(onchain_flags)
     if identity.get("verified"):
-        flags.append("KYC_VERIFIED")
-    return flags
+        flags.add("KYC_VERIFIED")
+    return sorted(flags)
 
 
 async def analyze(wallet_address: str) -> dict:


### PR DESCRIPTION
## Summary
- ensure `aggregate_flags` keeps flags sorted after KYC check
- clean unused imports and spacing in service

## Testing
- `flake8 src/scorelab_core/core.py app/services/scorelab_service.py`
- `PYTHONPATH=$(pwd) coverage run -m pytest tests/test_scorelab_core.py::test_aggregate_flags`
- `coverage report -m | head`

------
https://chatgpt.com/codex/tasks/task_e_6844113d580083329aea3190054125f0