### PR TITLE
Fix aggregate flags variable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic
 flake8
 pytest
 coverage
+cryptography


### PR DESCRIPTION
## Summary
- ensure `aggregate_flags` uses the `flags` variable
- add missing `cryptography` dependency for tests

## Testing
- `flake8 src/scorelab_core/core.py tests/test_scorelab_core.py`
- `pytest -q tests/test_scorelab_core.py`
- `coverage run -m pytest tests/test_scorelab_core.py && coverage report -m`


------
https://chatgpt.com/codex/tasks/task_e_6844151ab74c83329b8be1aeed3ba91c