### PR TITLE
Fix variable name in test

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -63,8 +63,8 @@ async def test_analysis_to_nft(monkeypatch):
             "/internal/v1/scorelab/analyze",
             json={"wallet_address": "0x" + "a" * 40},
         )
-    assert resp.status_code == 200
-    analysis = resp.json()
+    assert analysis_resp.status_code == 200
+    analysis = analysis_resp.json()
     assert analysis["wallet"] == "0x" + "a" * 40
 
     # Step 2: Mirror Engine comparison


### PR DESCRIPTION
## Summary
- rename `resp` to `analysis_resp` in the end-to-end test

## Testing
- `flake8`
- `pytest -q`
- `coverage run -m pytest && coverage report`


------
https://chatgpt.com/codex/tasks/task_e_6844151a3e1083328a62c923114f6384