### PR TITLE
Add db util re-exports

### DIFF
--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -1,0 +1,5 @@
+"""Compatibility module exposing wallet schemas."""
+
+from src.models import WalletData
+
+__all__ = ["WalletData"]

--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -1,5 +1,8 @@
 
-"""Wrapper around ``src.utils`` database helpers."""
+"""Database helpers using :mod:`motor` and caching connections."""
+
+from functools import lru_cache
+import os
 
 MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
 

--- a/src/utils/db.py
+++ b/src/utils/db.py
@@ -1,0 +1,18 @@
+"""Compatibility layer for database helpers."""
+
+from app.utils.db import get_client as app_get_client, get_db as app_get_db
+
+
+def get_client():
+    """Return the Motor client from :mod:`app.utils.db`."""
+
+    return app_get_client()
+
+
+def get_db():
+    """Return the main database handle from :mod:`app.utils.db`."""
+
+    return app_get_db()
+
+
+__all__ = ["get_client", "get_db"]

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 import httpx
 from httpx import AsyncClient
+import types
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from main import app  # noqa: E402
@@ -10,6 +11,8 @@ from app.routers.scorelab import router as scorelab_router  # noqa: E402
 from app.routers.mirror_engine import router as mirror_router  # noqa: E402
 from app.routers.sigilmesh import router as sigil_router  # noqa: E402
 from app.routers.compliance import router as compliance_router  # noqa: E402
+from app.services.compliance import compliance  # noqa: E402
+from app.services import sigilmesh  # noqa: E402
 
 app.include_router(scorelab_router)
 app.include_router(mirror_router)

--- a/tests/test_mirror_engine.py
+++ b/tests/test_mirror_engine.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pytest
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)

--- a/tests/test_sentinela.py
+++ b/tests/test_sentinela.py
@@ -16,6 +16,7 @@ app.include_router(sentinela_router)
 
 @pytest.mark.asyncio
 async def test_monitor_reanalyzes_on_event(monkeypatch):
+    called = {}
     analyzed = []
 
     async def mock_analyze(wallet_address: str):


### PR DESCRIPTION
## Summary
- expose `get_db` and `get_client` through `src.utils.db`
- add compatibility shim for models
- fix missing imports in db utils

## Testing
- `flake8` *(fails: undefined names, etc.)*
- `pytest -q` *(fails: NameError and syntax errors in tests)*
- `coverage run -m pytest && coverage report` *(fails: test collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68440107c5548332adb406b0886ec2b5