### PR TITLE
Implement sentinela monitor control

### DIFF
--- a/app/routers/sentinela.py
+++ b/app/routers/sentinela.py
@@ -1,40 +1,36 @@
 import asyncio
 from fastapi import APIRouter
-codex/remover-duplicação-e-definir-o-modelo-event
-
-from app.models.sentinela import Event
-from app.services import sentinela
- main
 
 from app.models.sentinela import Event
 from app.services import sentinela, scorelab_service
 from infra import event_bus
 
 router = APIRouter(prefix="/internal/v1/sentinela")
- 
-monitor_task: asyncio.Task | None = None
 
-codex/remover-duplicação-e-definir-o-modelo-event
+# Background task running the event monitor loop.
+_monitor_task: asyncio.Task | None = None
 
- codex/preencher-src/utils/db.py-com-lógica-de-app/utils/db.py
-class Event(BaseModel):
-    wallet: str | None = None
-    gas: int = 0
-    anomaly: bool = False
 
 @router.post("/start")
 async def start_monitor() -> dict:
     """Start monitoring wallet activity events."""
 
-    global monitor_task
-    if monitor_task and not monitor_task.done():
+    global _monitor_task
+    if _monitor_task and not _monitor_task.done():
         return {"status": "running"}
 
-    async def loop() -> None:
-        async for payload in event_bus.listen_events("wallet.activity"):
+    async def _run() -> None:
+        """Process incoming events and trigger analyses."""
+        events = sentinela.monitor_loop(event_bus.listen_events("wallet.activity"))
+        async for payload in events:
             await scorelab_service.analyze(payload["wallet_address"])
 
-    monitor_task = asyncio.create_task(loop())
+    def _clear_task(_: asyncio.Task) -> None:
+        global _monitor_task
+        _monitor_task = None
+
+    _monitor_task = asyncio.create_task(_run())
+    _monitor_task.add_done_callback(_clear_task)
     await asyncio.sleep(0)
     return {"status": "started"}
 
@@ -43,20 +39,17 @@ async def start_monitor() -> dict:
 async def stop_monitor() -> dict:
     """Stop the monitoring task if running."""
 
-    global monitor_task
-    if monitor_task and not monitor_task.done():
-        monitor_task.cancel()
+    global _monitor_task
+    if _monitor_task:
+        _monitor_task.cancel()
         try:
-            await monitor_task
+            await _monitor_task
         except asyncio.CancelledError:
             pass
-    monitor_task = None
+        _monitor_task = None
     return {"status": "stopped"}
- main
 
 
-
-main
 @router.post("/check")
 def check_event(event: Event) -> dict:
     """Check whether the given event would trigger a reanalysis."""


### PR DESCRIPTION
## Summary
- implement start/stop monitor endpoints
- manage async monitor background task with done callback

## Testing
- `flake8` *(fails: multiple indentation errors in unrelated files)*
- `pytest -q` *(fails: import and indentation errors in tests and other modules)*
- `coverage run -m pytest && coverage report` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684423c9b8348332aea03b58810bcf36