### PR TITLE
Fix get_db function in src.utils

### DIFF
--- a/src/utils/db.py
+++ b/src/utils/db.py
@@ -1,28 +1,12 @@
- codex/preencher-src/utils/db.py-com-lógica-de-app/utils/db.py
-"""Wrapper around ``src.utils`` database helpers."""
-
 import os
 from functools import lru_cache
+from motor.motor_asyncio import AsyncIOMotorClient
 
 MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
 
-
 @lru_cache()
-def get_client():
-    try:
-        from motor.motor_asyncio import AsyncIOMotorClient
-    except Exception as exc:  # pragma: no cover - optional dependency
-        raise ImportError("motor is required for database operations") from exc
+def get_client() -> AsyncIOMotorClient:
     return AsyncIOMotorClient(MONGODB_URI)
-
 
 def get_db():
     return get_client().foundlab
-
-"""Database utilities."""
-
-
-def get_db():
-    """Return a database handle (placeholder)."""
-    raise NotImplementedError
- main


### PR DESCRIPTION
## Summary
- implement MongoDB client helpers in `src.utils.db`

## Testing
- `flake8` *(fails: IndentationError in other modules)*
- `pytest -q` *(fails: missing dependencies)*
- `coverage run -m pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684423cad5fc8332bf7b83912f15892e