### PR TITLE
Fix aggregate_flags implementation and cleanup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,19 +3,8 @@ uvicorn
 motor
 httpx
 pydantic
- codex/preencher-src/utils/db.py-com-lógica-de-app/utils/db.py
-cryptography
-flake8
-pytest
-
-pytest-asyncio
 cryptography
 flake8>=7.2.0
 pytest>=8.3.5
-coverage
-cryptography
- codex/implement-kyc-logic-and-adjust-tests
 pytest-asyncio
-
- main
- main
+coverage

--- a/src/scorelab_core/core.py
+++ b/src/scorelab_core/core.py
@@ -9,19 +9,10 @@ analyze_wallet = sherlock.analyze_wallet
 
 def aggregate_flags(onchain_flags: List[str], identity: dict) -> List[str]:
     """Return a unique, sorted list of flags, adding a KYC flag when verified."""
-codex/fix-variável-aggregate_flags
-    flags = set(onchain_flags)
-
     flags = sorted(set(onchain_flags))
- main
     if identity.get("verified"):
- codex/preencher-src/utils/db.py-com-lógica-de-app/utils/db.py
         flags.append("KYC_VERIFIED")
     return flags
-
-        flags.add("KYC_VERIFIED")
-    return sorted(flags)
- main
 
 
 async def analyze(wallet_address: str) -> dict:

--- a/src/utils/db.py
+++ b/src/utils/db.py
@@ -1,28 +1,19 @@
- codex/preencher-src/utils/db.py-com-lógica-de-app/utils/db.py
-"""Wrapper around ``src.utils`` database helpers."""
+"""Database utilities for MongoDB access."""
 
 import os
 from functools import lru_cache
+
+from motor.motor_asyncio import AsyncIOMotorClient
 
 MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
 
 
 @lru_cache()
-def get_client():
-    try:
-        from motor.motor_asyncio import AsyncIOMotorClient
-    except Exception as exc:  # pragma: no cover - optional dependency
-        raise ImportError("motor is required for database operations") from exc
+def get_client() -> AsyncIOMotorClient:
+    """Return a cached Motor client instance."""
     return AsyncIOMotorClient(MONGODB_URI)
 
 
 def get_db():
+    """Return a handle to the FoundLab database."""
     return get_client().foundlab
-
-"""Database utilities."""
-
-
-def get_db():
-    """Return a database handle (placeholder)."""
-    raise NotImplementedError
- main


### PR DESCRIPTION
## Summary
- remove merge artifacts in `aggregate_flags`
- cleanup MongoDB utilities
- tidy requirements list

## Testing
- `flake8` *(fails: various style errors)*
- `pytest -q` *(fails: indentation and import errors)*
- `coverage run -m pytest && coverage report` *(fails: same errors as pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68440d518bb88332806429970c451e96