### PR TITLE
Add minimal frontend router

### DIFF
--- a/app/routers/frontend.py
+++ b/app/routers/frontend.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+
+@router.get("/ui", response_class=HTMLResponse, tags=["FrontEnd"])
+async def ui_page() -> str:
+    """Serve a minimal HTML interface for score calculation."""
+    return """
+    <html>
+      <head><title>FoundLab UI</title></head>
+      <body>
+        <h1>Score Wallet</h1>
+        <form id='score-form'>
+          Wallet: <input name='wallet_address'><br>
+          Tx Volume: <input type='number' name='tx_volume'><br>
+          Age Days: <input type='number' name='age_days'><br>
+          <button type='submit'>Submit</button>
+        </form>
+        <pre id='result'></pre>
+        <script>
+        const form = document.getElementById('score-form');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const data = Object.fromEntries(new FormData(form));
+            const resp = await fetch('/score/', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(data)
+            });
+            const json = await resp.json();
+            document.getElementById('result').textContent =
+                JSON.stringify(json, null, 2);
+        });
+        </script>
+      </body>
+    </html>
+    """

--- a/main.py
+++ b/main.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI
 from app.routers import score
 from app.routers import scorelab
+from app.routers import frontend
 
 app = FastAPI()
 app.include_router(score.router)
 app.include_router(scorelab.router)
+app.include_router(frontend.router)
 
 
 @app.get("/")

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from fastapi.testclient import TestClient  # noqa: E402
+from main import app  # noqa: E402
+
+
+def test_ui_page() -> None:
+    client = TestClient(app)
+    response = client.get('/ui')
+    assert response.status_code == 200
+    assert '<form' in response.text


### PR DESCRIPTION
## Summary
- add `/ui` endpoint that serves a simple HTML form
- include the new router in `main.py`
- test the UI endpoint

## Testing
- `flake8`
- `pytest tests/test_frontend.py -q`
- `coverage run -m pytest tests/test_frontend.py && coverage report`
- `pytest -q` *(fails: IndentationError in existing modules)*
- `coverage run -m pytest && coverage report` *(fails: IndentationError in existing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68496a680c9083328c3b39666385689a